### PR TITLE
Update protobuf-java to 3.25.5 if otherwise present in the project dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -187,3 +187,28 @@ jobs:
         with:
           modules-ignore: smithy4s-preprocessors_2.12
           configs-ignore: test scala-tool scala-doc-tool test-internal
+
+  validate-steward:
+    name: Validate Steward Config
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+        java: [temurin@11]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Checkout current branch (fast)
+        uses: actions/checkout@v4
+
+      - name: Setup Java (temurin@11)
+        id: setup-java-temurin-11
+        if: matrix.java == 'temurin@11'
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 11
+
+      - uses: coursier/setup-action@v1
+        with:
+          apps: scala-steward
+
+      - run: scala-steward validate-repo-config .scala-steward.conf

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -14,6 +14,7 @@ pull_request_rules:
     - body~=labels:.*early-semver-minor
   - status-success=Build and Test (ubuntu-latest, 2.13, temurin@8)
   - status-success=Build and Test (ubuntu-latest, 3, temurin@8)
+  - status-success=Validate Steward Config (ubuntu-latest, temurin@11)
   actions:
     merge: {}
 - name: Label rules PRs

--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -1,0 +1,3 @@
+updates.pin = [
+  { groupId = "com.google.protobuf", artifactId = "protobuf-java", version = "3." } # used transitively by ScalaMeta; CVE-2024-7254
+]

--- a/build.sbt
+++ b/build.sbt
@@ -23,6 +23,7 @@ ThisBuild / tlJdkRelease := Some(8)
 ThisBuild / githubWorkflowBuild := List(Sbt(List("compile", "test")))
 ThisBuild / tlCiReleaseBranches := Seq("main")
 ThisBuild / sonatypeCredentialHost := xerial.sbt.Sonatype.sonatypeLegacy
+ThisBuild / mergifyRequiredJobs ++= Seq("validate-steward")
 ThisBuild / mergifyStewardConfig ~= { _.map {
   _.withAuthor("dwolla-oss-scala-steward[bot]")
     .withMergeMinors(true)
@@ -49,6 +50,9 @@ lazy val `scalafix-rules` = project.in(file("scalafix/rules"))
       "ch.epfl.scala" %% "scalafix-core" % _root_.scalafix.sbt.BuildInfo.scalafixVersion cross CrossVersion.for3Use2_13,
       "org.scalameta" %% "munit" % "1.0.0" % Test,
       "com.eed3si9n.expecty" %% "expecty" % "0.16.0" % Test,
+    ),
+    dependencyOverrides ++= Seq(
+      "com.google.protobuf" % "protobuf-java" % "3.25.5", // CVE-2024-7254
     ),
     scalacOptions ~= {
       _.filterNot(_ == "-Xfatal-warnings")


### PR DESCRIPTION
This mitigates a security advisory introduced in #67. It's not a major concern because the dependency is only present in the Scalafix subproject, which is only used as part of this project's build and is not otherwise published, but it's good to clean it up anyway.