### PR TITLE
tweak tlCommandAliases to avoid smithy4s regenerating code when switching between Scala versions

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -27,6 +27,19 @@ ThisBuild / mergifyStewardConfig ~= { _.map {
   _.withAuthor("dwolla-oss-scala-steward[bot]")
     .withMergeMinors(true)
 }}
+Global / tlCommandAliases := {
+  def forEachScalaVersion(l: String *): Seq[String] =
+    githubWorkflowScalaVersions.value.flatMap { v =>
+      s"++ $v" :: l.toList
+    }
+
+  val base = List("reload", "project /")
+
+  Map(
+    "tlRelease" -> (base ++ forEachScalaVersion("mimaReportBinaryIssues", "publish") ++ List("tlSonatypeBundleReleaseIfRelevant")),
+    "tlReleaseLocal" -> (base ++ forEachScalaVersion("compile", "publishLocal"))
+  )
+}
 
 lazy val `smithy4s-preprocessors` = project
   .in(file("smithy4s-preprocessors"))


### PR DESCRIPTION
Hopefully this will work around https://github.com/disneystreaming/smithy4s/issues/1589.