### PR TITLE
Smithy4s Build Settings

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -92,7 +92,7 @@ lazy val `secure-config` = (project in file("."))
     smithy4sAwsSpecs ++= Seq(AWS.kms),
     scalacOptions += "-Wconf:src=src_managed/.*:s",
     Compile / smithy4sModelTransformers += "com.dwolla.config.smithy.ShadeNamespace",
-    Compile / smithy4sAllDependenciesAsJars += (`smithy4s-preprocessors` / Compile / packageBin).value,
+    Compile / smithy4sInternalDependenciesAsJars += (`smithy4s-preprocessors` / Compile / packageBin).value,
     Compile / smithy4sSmithyLibrary := false,
     Compile / scalafix / unmanagedSources := (Compile / sources).value,
     scalafixOnCompile := true,

--- a/build.sbt
+++ b/build.sbt
@@ -53,6 +53,7 @@ lazy val `smithy4s-preprocessors` = project
         "software.amazon.smithy" % "smithy-build" % smithy4s.codegen.BuildInfo.smithyVersion,
       )
     },
+    version := tlBaseVersion.value, // this module is unpublished and a stable version helps smithy4s not regenerate code more often than needed
   )
   .enablePlugins(NoPublishPlugin)
 


### PR DESCRIPTION
These changes, in conjunction with the smithy4s codegen plugin changes suggested in https://github.com/disneystreaming/smithy4s/pull/1590, should let us revert the build overrides made in #92. (We'll actually revert those changes once the smithy4s changes have been merged and published.)