### PR TITLE
Tweak noncompilation tests and add MiMa exclusions

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -92,6 +92,17 @@ lazy val `secure-config` = (project in file("."))
     Compile / smithy4sSmithyLibrary := false,
     Compile / scalafix / unmanagedSources := (Compile / sources).value,
     scalafixOnCompile := true,
+    mimaBinaryIssueFilters ++= {
+      import com.typesafe.tools.mima.core.*
+
+      // exclusions in this package should be safe since everything in there should be package private
+      val shadedPackage = "com.dwolla.config.smithy_shaded.com.amazonaws.kms"
+
+      Seq(
+        ProblemFilters.exclude[FinalMethodProblem](s"$shadedPackage.KMSOperation#Transformed.transform"),
+        ProblemFilters.exclude[FinalMethodProblem](s"$shadedPackage.KMSOperation#reified.transform"),
+      )
+    }
   )
   .enablePlugins(
     Smithy4sCodegenPlugin,

--- a/build.sbt
+++ b/build.sbt
@@ -77,6 +77,14 @@ lazy val `secure-config` = (project in file("."))
         "org.http4s" %% "http4s-ember-client" % "0.23.28" % Test,
       )
     },
+    libraryDependencies ++= {
+      (scalaBinaryVersion.value) match {
+        case "2.13" =>
+          Seq("org.scala-lang" % "scala-compiler" % scalaVersion.value % Test)
+        case _ =>
+          Nil
+      }
+    },
     smithy4sAwsSpecs ++= Seq(AWS.kms),
     scalacOptions += "-Wconf:src=src_managed/.*:s",
     Compile / smithy4sModelTransformers += "com.dwolla.config.smithy.ShadeNamespace",


### PR DESCRIPTION
## Test Changes

There is currently an issue in this repo that can cause the Scala 3 tests (and prior to this PR, the Scala 2.13 tests) to falsely fail. Essentially it's a compilation order issue; when the tests use macros to compile example strings in the test, the tests must be compiled after the generated Smithy4s code, as-modified by our Scalafix. 

In other words, if you run in sbt

```
clean; ++ 3; Test/compile; test
```
the tests will fail, because the Smithy4s code is generated and modified in the following order:

1. `Test/compile` is triggered, which depends on `Compile/compile`.
2. `Compile/compile` is therefore triggered, which depends on Smithy4s codegen.
3. Smithy4s codegen is therefore triggered.
4. `Compile/compile` runs.
5. `Test/compile` runs, notably compiling the macros which reference code in the `com.dwolla.config.smithy_shaded.com.amazonaws.kms` package, which is not yet modified to be package-private.
6. The generated code is modified by our Scalafix, which also uses the output of `Compile/compile` for semantic information. This is when the package-private modification happens.
7. Finally, when `test` is executed, sbt and/or the incremental compiler are not smart enough to recognize that the macro code needs to be recompiled due to the modifications in step 6, and the tests fail.

Prior to this PR, the same would be true if you ran `clean; ++ 2.13; Test/compile; test`. After this PR is merged, those commands would succeed, because the Scala 2.13 tests no longer use macros to compile the strings, but instead use the reflection library. 

Unfortunately, as far as I can tell, the reflection library no longer supports this functionality in Scala 3, where you're expected to use macros instead. Luckily we don't really _need_ to run `Test/compile` in our builds and can just use `compile` instead.

## MiMa Exclusions

Updating Smithy4s to `v0.18.25` to pull the fixes to codegen caching also includes a welcome change to make the library friendlier for use with cats-tagless. The changes to the generated code are not binary compatible, but as far as I can tell the problematic methods are not accessible outside the `com.dwolla.config.smithy_shaded.com.amazonaws.kms` package, so we make no binary compatibility guarantees to downstream users who use them directly anyway.